### PR TITLE
Boolean Attributes Getting Flipped

### DIFF
--- a/Incremental Store/CMDEncryptedSQLiteStore.m
+++ b/Incremental Store/CMDEncryptedSQLiteStore.m
@@ -1041,7 +1041,7 @@ static NSString * const CMDEncryptedSQLiteStoreMetadataTableName = @"meta";
             
             // boolean
             else if (type == NSBooleanAttributeType) {
-                sqlite3_bind_int(statement, index, [value boolValue] ? 0 : 1);
+                sqlite3_bind_int(statement, index, [value boolValue] ? 1 : 0);
             }
             
             // date


### PR DESCRIPTION
We bumped into an issue where boolean attributes using encrypted-core-data were getting flipped when we went back to read them. This should fix the issue.
