### PR TITLE
Fixes to make inheritance work for fetch requests and adding support for direct relationships.

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -1200,7 +1200,7 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
     if (predicateString == nil) {
         return @"";
     }
-    NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:@"\\b(\\S+?\\.\\S+?)\\b" options:0 error:nil];
+    NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:@"\\b(\\w+\\.[^= ]+)\\b" options:0 error:nil];
     NSArray* matches = [regex matchesInString:predicateString options:0 range:NSMakeRange(0, [predicateString length])];
     for ( NSTextCheckingResult* match in matches )
     {


### PR DESCRIPTION
This is the version of https://github.com/project-imas/encrypted-core-data/pull/19 that only supports direct relationships instead of arbitrarily deep relationships. EG:

This is supported:
WHERE reletedEntity.id = 10
But this is not supported:
WHERE reletedEntity.anotherRelatedEntity.id = 10

Note that from a speed perspective this is likely just as fast as pull/19, it's just that the super deep nested relationships that pull/19 also supports will probably slow things down. I haven't profiled it though so I really don't know, just assuming since every relationship adds an additional join clause.
