### PR TITLE
support for IS NULL predicate

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -1557,7 +1557,11 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
         NSMutableArray *comparisonBindings = [NSMutableArray arrayWithCapacity:2];
         if (leftBindings)  [comparisonBindings addObject:leftBindings];
         if (rightBindings) [comparisonBindings addObject:rightBindings];
-        query = [@[leftOperand, [operator objectForKey:@"operator"], rightOperand] componentsJoinedByString:@" "];
+        if (rightOperand && !rightBindings) {
+            query = [@[leftOperand, @"IS", rightOperand] componentsJoinedByString:@" "];
+        } else {
+            query = [@[leftOperand, [operator objectForKey:@"operator"], rightOperand] componentsJoinedByString:@" "];
+        }
         bindings = [[comparisonBindings cmdFlatten] mutableCopy];
     }
 


### PR DESCRIPTION
hi

it seems that support for NSPredicate "== nil" (resulting in IS NULL) was missing.
I've added some solution to this problem, although it does not play nice with the current approach to operator (operators NSDIctionary). So basically the "=" operator needs to be replaced with "IS" for IS NULL to work. I've just accomplished it by a check if there is an rightOperand but no rightBindings. In this case we might (?) assume that it's a "IS NULL" case and provide a special version of query.
What do you think?

Best regards
Rafal
