### PR TITLE
Fix migration database name with ecd prefix

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -770,9 +770,9 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
                             error:(NSError**)error {
     NSString *string;
     sqlite3_stmt *statement;
-    NSString *sourceEntityName = [sourceEntity name];
+    NSString *sourceEntityName = [NSString stringWithFormat:@"ecd%@", [sourceEntity name]];
     NSString *temporaryTableName = [NSString stringWithFormat:@"_T_%@", sourceEntityName];
-    NSString *destinationTableName = [destinationEntity name];
+    NSString *destinationTableName = [NSString stringWithFormat:@"ecd%@", [destinationEntity name]];
     
     // move existing table to temporary new table
     string = [NSString stringWithFormat:


### PR DESCRIPTION
When testing the migration, I observe that database name for source and destination are not prefixed with "ecd". So, sqlite did not find the source table.
The migration was not completed.
