### PR TITLE
fix for issue #118

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -377,8 +377,8 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
             id value = [self valueForProperty:property inStatement:statement atIndex:idx];
             if (value) {
                 [dictionary setObject:value forKey:obj];
-                [allProperties addObject:property];
             }
+            [allProperties addObject:property];
         }];
         sqlite3_finalize(statement);
         NSIncrementalStoreNode *node = [[CMDIncrementalStoreNode alloc]
@@ -2093,16 +2093,15 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
 
 - (void)updateWithChangedValues:(NSDictionary *)changedValues
 {
-    NSMutableDictionary * updateValues = [NSMutableDictionary dictionaryWithCapacity:self.allProperties.count];
+    NSMutableDictionary *allValues = [NSMutableDictionary dictionaryWithDictionary:changedValues];
     for (NSPropertyDescription * key in self.allProperties) {
-        id newValue = [changedValues objectForKey:key.name];
-        if (newValue) {
-            [updateValues setObject:newValue forKey:key.name];
-        } else {
-            [updateValues setObject:[self valueForPropertyDescription:key] forKey:key.name];
+        id newValue = [allValues objectForKey:key.name];
+        if(!newValue){
+            [allValues setObject:[self valueForPropertyDescription:key] forKey:key.name];
         }
     }
-    [self updateWithValues:updateValues version:self.version+1];
+    [self updateWithValues:allValues version:self.version+1];
+
 }
 
 @end


### PR DESCRIPTION
Fix for #118

self.allProperties now also contains NSPropertyDescriptions for all properties (even if nil when node created). 
Updating the node's values now takes into account previously nil properties.

I'm not sure if self.allProperties is used elsewhere such that including nil properties could be an issue?
