### PR TITLE
Warnings and static analyzer fixes

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -1056,7 +1056,10 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
     
     BOOL result = (statement != NULL && sqlite3_finalize(statement) == SQLITE_OK);
     if (!result) {
-        *error = [self databaseError];
+        if (error)
+        {
+            *error = [self databaseError];
+        }
         return result;
     }
     
@@ -1083,7 +1086,10 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
         sqlite3_step(statement);
         BOOL result = (statement != NULL && sqlite3_finalize(statement) == SQLITE_OK);
         if (!result) {
-            *error = [self databaseError];
+            if (error)
+            {
+                *error = [self databaseError];
+            }
             return result;
         }
     }
@@ -1107,7 +1113,10 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
         sqlite3_step(statement);
         BOOL result = (statement != NULL && sqlite3_finalize(statement) == SQLITE_OK);
         if (!result) {
-            *error = [self databaseError];
+            if (error)
+            {
+                *error = [self databaseError];
+            }
             return result;
         }
     }


### PR DESCRIPTION
The warnings and static analyzer started getting annoying.

Even though this shouldn't affect functionality, feel free to decline it. Compiling with Xcode 6 just gets grumpy and constantly warns on these items.
