### PR TITLE
Better error handling

### DIFF
--- a/Incremental Store/EncryptedStore.h
+++ b/Incremental Store/EncryptedStore.h
@@ -24,7 +24,8 @@ extern NSString * const EncryptedStoreCacheSize;
 
 typedef NS_ENUM(NSInteger, EncryptedStoreError)
 {
-    EncryptedStoreErrorIncorrectPasscode = 6000
+    EncryptedStoreErrorIncorrectPasscode = 6000,
+    EncryptedStoreErrorMigrationFailed
 };
 
 @interface EncryptedStore : NSIncrementalStore

--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -688,8 +688,12 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
                         }
                         
                     } else {
-						NSLog(@"Failed to create NSManagedObject models for migration.");
-						return NO;
+                        NSLog(@"Failed to create NSManagedObject models for migration.");
+                        if (error) {
+                            NSDictionary * userInfo = @{EncryptedStoreErrorMessageKey : @"Missing old model, cannot migrate database"};
+                            *error = [NSError errorWithDomain:EncryptedStoreErrorDomain code:EncryptedStoreErrorMigrationFailed userInfo:userInfo];
+                        }
+                        return NO;
 					}
                 }
                 
@@ -736,7 +740,7 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
     }
     
     // load failed
-    if (error) { *error = [self databaseError]; }
+    if (error && *error == nil) { *error = [self databaseError]; }
     sqlite3_close(database);
     database = NULL;
     return NO;


### PR DESCRIPTION
Creates a custom error if we detect not enough information to perform migration.

Also, don't override error if we already set it.
