### PR TITLE
unit tests now pass when running on 64 bit simulators

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -2816,7 +2816,7 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
 
 -(unsigned long)typeHash
 {
-    unsigned long hash = (unsigned long) self.name.hash;
+    unsigned long hash = (uint32_t) self.name.hash;
     return hash;
 }
 


### PR DESCRIPTION
Fixes bug on 64 bit that had problems with signing. There was in fact a good reason in the original code to chop of the most significant bits.

This is a fix to get things back to normal. I'm going to propose a more radical change to make the signed interaction with SQLite more obvious. (That PR can be rejected by all means)
