### PR TITLE
Signed fixes

### DIFF
--- a/exampleProjects/IncrementalStore/Tests/IncrementalStoreTests.m
+++ b/exampleProjects/IncrementalStore/Tests/IncrementalStoreTests.m
@@ -29,7 +29,7 @@
 
 + (void)initialize {
     if (self == [IncrementalStoreTests class]) {
-        srand(time(NULL));
+        srand((int)time(NULL));
     }
 }
 


### PR DESCRIPTION
Fixes all warnings due to casting/signedness (Lets pretend that is a word...)

Unit tests passing on 32 & 64 bit simulators

No warnings or static analyzer errors on either architectures

Typehash is now signed as it should be as it is used as a column in sqlite.
