### PR TITLE
Support for recursive many-to-many relationships

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -1304,12 +1304,19 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
     NSEntityDescription *rootSourceEntity = [self rootForEntity:relationship.entity];
     NSEntityDescription *rootDestinationEntity = [self rootForEntity:relationship.destinationEntity];
     
+    static NSString *format = @"%@__objectid";
+    
+    if ([rootSourceEntity isEqual:rootDestinationEntity]) {
+        *firstIDColumn = [NSString stringWithFormat:format, [rootSourceEntity.name stringByAppendingString:@"_1"]];
+        *secondIDColumn = [NSString stringWithFormat:format, [rootDestinationEntity.name stringByAppendingString:@"_2"]];
+        
+        return YES;
+    }
+    
     NSArray *orderedEntities = [@[rootSourceEntity, rootDestinationEntity] sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:NSStringFromSelector(@selector(name)) ascending:YES comparator:[self fixedLocaleCaseInsensitiveComparator]]]];
     
     NSEntityDescription *firstEntity = [orderedEntities firstObject];
     NSEntityDescription *secondEntity = [orderedEntities lastObject];
-    
-    static NSString *format = @"%@__objectid";
     
     // 1st
     *firstIDColumn = [NSString stringWithFormat:format, firstEntity.name];

--- a/exampleProjects/IncrementalStore/ClassModel.xcdatamodeld/ClassModel.xcdatamodel/contents
+++ b/exampleProjects/IncrementalStore/ClassModel.xcdatamodeld/ClassModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="5064" systemVersion="13E28" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14B25" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="ChildA" representedClassName="ISDChildA" parentEntity="Parent" syncable="YES">
         <attribute name="attributeA" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
@@ -17,11 +17,13 @@
         <relationship name="manyToMany" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Parent" inverseName="manyToManyInverse" inverseEntity="Parent" syncable="YES"/>
         <relationship name="oneToMany" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Parent" inverseName="oneToManyInverse" inverseEntity="Parent" syncable="YES"/>
         <relationship name="oneToOne" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Parent" inverseName="oneToOneInverse" inverseEntity="Parent" syncable="YES"/>
+        <relationship name="recursiveManyToMany" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Root" inverseName="recursiveManyToManyInverse" inverseEntity="Root" syncable="YES"/>
+        <relationship name="recursiveManyToManyInverse" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Root" inverseName="recursiveManyToMany" inverseEntity="Root" syncable="YES"/>
     </entity>
     <elements>
         <element name="ChildA" positionX="-119" positionY="144" width="128" height="58"/>
         <element name="ChildB" positionX="79" positionY="144" width="128" height="58"/>
         <element name="Parent" positionX="-20" positionY="8" width="128" height="103"/>
-        <element name="Root" positionX="-236" positionY="8" width="128" height="103"/>
+        <element name="Root" positionX="-236" positionY="8" width="128" height="133"/>
     </elements>
 </model>


### PR DESCRIPTION
Using recursive many-to-many relationships resulted in a "duplicate column name" error. I've fixed the issue by simply appending "_1" and "_2" to the column names of the many-to-many table if the source and destination entities are equal.