### PR TITLE
Travis work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: objective-c
 
+compiler:
+	- clang
+
 before_install:
     - brew update
     - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ before_install:
     - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
 
 script:
-    - cd "exampleProjects/IncrementalStore"
+    - pushd vendor/sqlcipher/sqlcipher.xcodeproj
+    - cp project.pbxproj proj.tmp
+    - sed 's/ CFLAGS=../ CFLAGS=\\"-miphoneos-version-min=6.0 /' proj.tmp > project.pbxproj
+    - popd
+    - cd exampleProjects/IncrementalStore
     # 32-bit tests
     - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone 5"
-    - cat ../../vendor/sqlcipher/config.log
     # 64-bit tests
     - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone 5s"
-    - cat ../../vendor/sqlcipher/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ script:
     - gcc --version
     # 32-bit tests
     - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone 5"
+    - cat config.log
     # 64-bit tests
     - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone 5s"
+    - cat config.log
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 
 compiler:
-	- clang
+    - clang
 
 before_install:
     - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,9 @@ before_install:
 
 script:
     - cd "exampleProjects/IncrementalStore"
-    - clang --version
-    - gcc --version
     # 32-bit tests
     - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone 5"
-    - cat config.log
+    - cat ../../vendor/sqlcipher/config.log
     # 64-bit tests
     - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone 5s"
-    - cat config.log
-
+    - cat ../../vendor/sqlcipher/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
 
 script:
     - cd "exampleProjects/IncrementalStore"
-    - export CC=clang
-    - export CXX=clang
+    - clang --version
+    - gcc --version
     # 32-bit tests
     - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone 5"
     # 64-bit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: objective-c
 
-compiler:
-    - clang
-
 before_install:
     - brew update
     - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
 
 script:
     - cd "exampleProjects/IncrementalStore"
+    - export CC=clang
+    - export CXX=clang
     # 32-bit tests
-    - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone Retina (4-inch)"
+    - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone 5"
     # 64-bit tests
-    - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone Retina (4-inch 64-bit)"
+    - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone 5s"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
 
 script:
-    #- cd "exampleProjects/IncrementalStore"
+    - cd "exampleProjects/IncrementalStore"
     # 32-bit tests
     - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone Retina (4-inch)"
     # 64-bit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
 
 script:
-    - cd "exampleProjects/IncrementalStore"
+    #- cd "exampleProjects/IncrementalStore"
     # 32-bit tests
     - xctool -sdk iphonesimulator -scheme "Incremental Store Demo" clean test -destination "name=iPhone Retina (4-inch)"
     # 64-bit tests


### PR DESCRIPTION
A bit hacky, but added scripting to travis yaml that fixes errors causing compilation during xctool testing to fail -- also changed "name=iPhone Retina ..." to "name=iPhone 5" and "name=iPhone 5s" for 32bit and 64bit repectively, per apple specification