### PR TITLE
Added tests for issue 103 and fixed the ambiguous column name bug

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -2012,10 +2012,18 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
 }
 
 - (NSString *) getJoinClause: (NSFetchRequest *) fetchRequest withPredicate:(NSPredicate*)predicate initial:(BOOL)initial{
-    
+    return [self getJoinClause:fetchRequest withPredicate:predicate initial:initial withStatements:nil];
+}
+
+- (NSString *) getJoinClause: (NSFetchRequest *) fetchRequest withPredicate:(NSPredicate*)predicate initial:(BOOL)initial withStatements: (NSMutableSet *) previousJoinStatementsSet {
     NSEntityDescription *entity = [fetchRequest entity];
     // We use a set to only add one join table per relationship.
-    NSMutableSet *joinStatementsSet = [NSMutableSet set];
+    NSMutableSet *joinStatementsSet;
+    if (previousJoinStatementsSet != nil) {
+        joinStatementsSet = previousJoinStatementsSet;
+    } else {
+        joinStatementsSet = [NSMutableSet set];
+    }
     // We use an array to ensure the order of join statements
     NSMutableArray *joinStatementsArray = [NSMutableArray array];
     
@@ -2035,7 +2043,7 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
     if ([predicate isKindOfClass:[NSCompoundPredicate class]]) {
         NSCompoundPredicate * compoundPred = (NSCompoundPredicate*) predicate;
         for (id subpred in [compoundPred subpredicates]){
-            [joinStatementsArray addObject:[self getJoinClause:fetchRequest withPredicate:subpred initial:NO]];
+            [joinStatementsArray addObject:[self getJoinClause:fetchRequest withPredicate:subpred initial:NO withStatements: joinStatementsSet]];
         }
     }
     else if ([predicate isKindOfClass:[NSComparisonPredicate class]]){

--- a/exampleProjects/IncrementalStore/Tests/IncrementalStoreTests.m
+++ b/exampleProjects/IncrementalStore/Tests/IncrementalStoreTests.m
@@ -726,6 +726,30 @@
     }];
 }
 
+-(void)test_predicateForObjectRelation_multipleAttributes {
+    NSError __block *error = nil;
+    NSUInteger count = 3;
+    NSFetchRequest __block *request = nil;
+    [self createUsersWithTagsDictionary:count];
+    
+    request = [[NSFetchRequest alloc] initWithEntityName:@"User"];
+    NSArray *users = [context executeFetchRequest:request error:&error];
+    
+    [users enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        error = nil;
+        request = [[NSFetchRequest alloc] initWithEntityName:@"Tag"];
+        NSString *name = [obj valueForKey:@"name"];
+        NSNumber *age = [obj valueForKey:@"age"];
+        [request setPredicate:
+         [NSPredicate predicateWithFormat:@"ANY hasUsers.name = %@ AND hasUsers.age = %@", name, age]];
+        NSArray *tags = [context executeFetchRequest:request error:&error];
+        XCTAssertNil(error, @"Unable to perform fetch request.");
+        XCTAssertEqual([tags count], count, @"Invalid number of results.");
+        NSManagedObject *tag = [tags lastObject];
+        XCTAssertNotNil(tag, @"No object found.");
+    }];
+}
+
 -(void)test_predicateEqualityComparison {
     NSError __block *error = nil;
     NSUInteger count = 3;


### PR DESCRIPTION
The ambiguous column name error occurred when a predicate tests multiple attributes within a relationship, because this results in multiple, identical joins, which share a name. Implemented the quick fix suggested by @aruggles in the comments. Fixes #103.