### PR TITLE
Lightweight migration fixes

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -684,8 +684,7 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
                 if ([[options objectForKey:NSMigratePersistentStoresAutomaticallyOption] boolValue] &&
                     [[options objectForKey:NSInferMappingModelAutomaticallyOption] boolValue]) {
                     NSMutableArray *bundles = [NSMutableArray array];
-                    [bundles addObjectsFromArray:[NSBundle allBundles]];
-                    [bundles addObjectsFromArray:[NSBundle allFrameworks]];
+                    [bundles addObject:[NSBundle mainBundle]];
                     NSManagedObjectModel *oldModel = [NSManagedObjectModel
                                                       mergedModelFromBundles:bundles
                                                       forStoreMetadata:metadata];
@@ -910,7 +909,7 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
 #pragma mark - migration helpers
 
 - (BOOL)migrateFromModel:(NSManagedObjectModel *)fromModel toModel:(NSManagedObjectModel *)toModel error:(NSError **)error {
-    BOOL __block succuess = YES;
+    BOOL __block success = YES;
     
     // generate mapping model
     NSMappingModel *mappingModel = [NSMappingModel
@@ -939,27 +938,25 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
         
         // add a new entity from final snapshot
         if (type == NSAddEntityMappingType) {
-            succuess = [self createTableForEntity:destinationEntity error:error];
+            success &= [self createTableForEntity:destinationEntity error:error];
         }
         
         // drop table for deleted entity
         else if (type == NSRemoveEntityMappingType) {
-            succuess = [self dropTableForEntity:sourceEntity];
+            success &= [self dropTableForEntity:sourceEntity];
         }
         
         // change an entity
         else if (type == NSTransformEntityMappingType) {
-            succuess = [self
+            success &= [self
                         alterTableForSourceEntity:sourceEntity
                         destinationEntity:destinationEntity
                         withMapping:entityMapping
                         error:error];
         }
-        
-        if (!succuess) { *stop = YES; }
     }];
     
-    return succuess;
+    return success;
 }
 
 - (BOOL)initializeDatabase:(NSError**)error {


### PR DESCRIPTION
1) You should only search for MOMs inside main bundle, not in allBundles+allFrameworks.
allBundles methods returns both .momd bundle and .app bundle and there will be a collision (duplicate entities). It only happens when you have more than one version of the same managed object model (when .momd is present inside an .app bundle)

2) migrateFromModel method stops on the first entity that failed to merge. Instead, it should try to merge  all entities and combine "success" variable from all attempts, not only the last one.
For some reason, when using parent-entities, alterTableForSourceEntity:... will sometimes fail when migrating an empty database, but other entities will migrate properly.