### PR TITLE
Bug fix when migrating relationships that have been renamed

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -1199,10 +1199,6 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
     }
     
     // get columns
-    if ([destinationTableName isEqualToString:@"ecdStudentInformation"])
-    {
-        ;
-    }
     NSMutableArray *sourceColumns = [NSMutableArray array];
     NSMutableArray *destinationColumns = [NSMutableArray array];
     [[mapping attributeMappings] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {

--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -2233,6 +2233,10 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
                 NSEntityDescription * e = [[[self persistentStoreCoordinator] managedObjectModel] entitiesByName][expressionDescription.name];
                 return [self newObjectIDForEntity:e referenceObject:number];
             }
+            else
+            {
+                return nil;
+            }
             break;
             
             /*  NSUndefinedAttributeType

--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -1500,19 +1500,19 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
         sqlite3_bind_int64(statement, 1, [number unsignedLongLongValue]);
         
         // bind properties
-        NSUInteger __block columnIndex;
+        int __block columnIndex;
         [keys enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
             // SQL indexes start at 1
-            columnIndex = idx + 1;
+            columnIndex = (int)idx + 1;
             NSPropertyDescription *property = [properties objectForKey:obj];
             // Add 1 to column index as the first bind is the objectID
-            [self bindProperty:property withValue:[object valueForKey:obj] forKey:obj toStatement:statement atIndex:(int)columnIndex + 1];
+            [self bindProperty:property withValue:[object valueForKey:obj] forKey:obj toStatement:statement atIndex:columnIndex + 1];
         }];
         
         if (containsOrder) {
             columnIndex++;
             for (NSDictionary * dict in orderValues) {
-                sqlite3_bind_int(statement, columnIndex + 1, [[dict objectForKey:@"v"] integerValue]);
+                sqlite3_bind_int(statement, columnIndex + 1, [[dict objectForKey:@"v"] intValue]);
                 columnIndex++;
             }
         }
@@ -1618,7 +1618,7 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
                     }
                     
                     [columns addObject:[NSString stringWithFormat:@"%@=?", column]];
-                    [columns addObject:[NSString stringWithFormat:@"%@=%d", orderColumn, [orderSequence integerValue]]];
+                    [columns addObject:[NSString stringWithFormat:@"%@=%ld", orderColumn, (long)[orderSequence integerValue]]];
                     
                     [keys addObject:key];
                 }
@@ -2659,12 +2659,12 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
         // string
         if ([obj isKindOfClass:[NSString class]]) {
             const char* str = [obj UTF8String];
-			int len = strlen(str);
+			int len = (int)strlen(str);
 
 			if (str[0] == '\'' && str[len-1] == '\'')
-				sqlite3_bind_text(statement, (idx + 1), str+1, len-2, SQLITE_TRANSIENT);
+				sqlite3_bind_text(statement, ((int)idx + 1), str+1, len-2, SQLITE_TRANSIENT);
 			else
-				sqlite3_bind_text(statement, (idx + 1), str, len, SQLITE_TRANSIENT);
+				sqlite3_bind_text(statement, ((int)idx + 1), str, len, SQLITE_TRANSIENT);
         }
 
         // number

--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -131,35 +131,6 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
 
     }
     
-    //
-    // Determine if a core data DB migration is necessary.
-    //
-    DDLogWarn(@"%@:%@ Determine if a core data DB migration is necessary.", THIS_FILE, THIS_METHOD);
-    NSError *error = nil;
-    
-    NSDictionary *sourceMetadata = [NSPersistentStoreCoordinator metadataForPersistentStoreOfType:EncryptedStoreType
-                                                                                              URL:databaseURL
-                                                                                            error:&error];
-    if (error)
-    {
-        DDLogError(@"%@:%@ : DB migration check ERROR: %@", THIS_FILE, THIS_METHOD, [error description]);
-    }
-    else
-    {
-        NSManagedObjectModel *destinationModel = [persistentCoordinator managedObjectModel];
-        BOOL pscCompatibile = [destinationModel isConfiguration:nil compatibleWithStoreMetadata:sourceMetadata];
-        
-        AppDelegate *appDelegate;
-        appDelegate.resetFormTemplates = !pscCompatibile;
-        
-#ifdef DEBUG
-        if (!pscCompatibile)
-            DDLogWarn(@"%@:%@ - DB Changed!  Coredata migration is necessary...", THIS_FILE, THIS_METHOD);
-        else
-            DDLogWarn(@"%@:%@ - No DB changes.", THIS_FILE, THIS_METHOD);
-#endif
-    }
-    
     NSPersistentStore *store = [persistentCoordinator
                                 addPersistentStoreWithType:EncryptedStoreType
                                 configuration:nil

--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -1204,7 +1204,8 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
         }
     }];
     [[mapping relationshipMappings] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-        NSRelationshipDescription * relationship = [sourceEntity relationshipsByName][[obj name]];
+        NSRelationshipDescription *destinationRelationship = [destinationEntity relationshipsByName][[obj name]];
+        NSRelationshipDescription * relationship = [sourceEntity relationshipsByName][([destinationRelationship renamingIdentifier] ? [destinationRelationship renamingIdentifier] : [obj name])];
         if (![relationship isToMany])
         {
             NSExpression *expression = [obj valueExpression];


### PR DESCRIPTION
The old code would unconditionally look at the new name being used, and would attempt to locate the relationship in the source entity by the new name. This would only work if the relationship's name has not been changed. As per recommendation by Apple's document, the user is expected to use Renaming ID found in the Data Model when renaming attributes/relationships. The code fix will first attempt to read from the renamingIdentifier property in the destination source. If no such information can be found, we can make the assumption that the relationship's name has not changed and will use it as is.