### PR TITLE
Fix abstract conflit

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -2,6 +2,7 @@
 // EncryptedStore.m
 //
 // Copyright 2012 - 2014 The MITRE Corporation, All Rights Reserved.
+// Modified by Maicon Peixinho - 7/17/15
 //
 
 #if !__has_feature(objc_arc)


### PR DESCRIPTION
Sometimes when more than one table inherence from Abstract, we got "could not prepare statement" because there is a conflict with the fields name (same).