### PR TITLE
Bug fix for faulting objects

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -428,6 +428,12 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
 
                     // Create the join
                     NSString *join = [NSString stringWithFormat:@" INNER JOIN %@ ON %@.__objectid=%@.%@", destinationTable, destinationTable, table, column];
+                    
+                    // this part handles optional relationship
+                    if (relationship.optional) {
+                        join = [join stringByAppendingFormat:@" OR %@.%@ IS NULL", table, column];
+                    }
+                    
                     [typeJoins addObject:join];
 
                     // Mark that this relation needs a type lookup

--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -429,6 +429,7 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
                     // Create the join
                     NSString *join = [NSString stringWithFormat:@" INNER JOIN %@ ON %@.__objectid=%@.%@", destinationTable, destinationTable, table, column];
                     
+                    
                     // this part handles optional relationship
                     if (relationship.optional) {
                         join = [join stringByAppendingFormat:@" OR %@.%@ IS NULL", table, column];


### PR DESCRIPTION
When there are some optional relationships, those columns corresponding to the relationships could be NULL, and therefore, the conditions for joining tables should take account into this effect.