### PR TITLE
Bool predicates

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -2905,6 +2905,14 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
         if (rightBindings) [comparisonBindings addObject:rightBindings];
         bindings = [[comparisonBindings cmdFlatten] mutableCopy];
     }
+    
+    else if ([predicate isEqual:[NSPredicate predicateWithValue:YES]]) {
+        query = @"1";
+    }
+    
+    else if ([predicate isEqual:[NSPredicate predicateWithValue:NO]]) {
+        query = @"0";
+    }
 
     NSString *entityWhere = nil;
     if (request.entity.superentity != nil) {

--- a/exampleProjects/IncrementalStore/Tests/IncrementalStoreTests.m
+++ b/exampleProjects/IncrementalStore/Tests/IncrementalStoreTests.m
@@ -813,4 +813,49 @@
     }];
 }
 
+-(void)test_predicateWithBoolValue
+{
+    const NSUInteger usersCount = 30;
+    
+    [self createUsers:usersCount];
+    
+    NSFetchRequest *req = [[NSFetchRequest alloc] initWithEntityName:@"User"];
+    NSError *error;
+    
+    // Test true predicate
+    req.predicate = [NSPredicate predicateWithValue:YES];
+    NSUInteger count = [context countForFetchRequest:req error:&error];
+    XCTAssertNil(error, @"Unable to perform fetch request.");
+    XCTAssertTrue(count == usersCount, @"Incorrect fetch count.");
+    
+    // Test false predicate
+    req.predicate = [NSPredicate predicateWithValue:NO];
+    count = [context countForFetchRequest:req error:&error];
+    XCTAssertNil(error, @"Unable to perform fetch request.");
+    XCTAssertTrue(count == 0, @"Incorrect fetch count.");
+}
+
+-(void)test_predicateCompound
+{
+    const NSUInteger usersCount = 30;
+    
+    [self createUsers:usersCount];
+    
+    __block NSError *error = nil;
+    
+    [@{ [NSPredicate predicateWithFormat:@"TRUEPREDICATE && FALSEPREDICATE"] : @(0),
+        [NSPredicate predicateWithFormat:@"TRUEPREDICATE || FALSEPREDICATE"] : @(usersCount),
+        [NSPredicate predicateWithFormat:@"!TRUEPREDICATE"] : @(0),
+        } enumerateKeysAndObjectsUsingBlock:^(NSPredicate *predicate, NSNumber *expectedCount, BOOL *stop) {
+            
+            NSFetchRequest *req = [[NSFetchRequest alloc] initWithEntityName:@"User"];
+            req.predicate = predicate;
+            
+            NSUInteger count = [context countForFetchRequest:req error:&error];
+            
+            XCTAssertFalse(count == NSNotFound, @"Error with fetch: %@", error);
+            XCTAssertEqual(count, [expectedCount unsignedIntegerValue], @"Incorrect fetch count");
+        }];
+}
+
 @end


### PR DESCRIPTION
Hi,

I've found a bug with bool value predicates support. A fetch request with compound predicate containing bool value predicate fails with SQL syntax error. I discovered that where clause forming method returns empty string for bool value predicates and it causes SQL syntax error for compound predicate or incorrect results for false predicate.