### PR TITLE
Preserve ObjectIDs when migrating tables

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -1294,8 +1294,8 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
     }
 
     // get columns
-    NSMutableArray *sourceColumns = [NSMutableArray array];
-    NSMutableArray *destinationColumns = [NSMutableArray array];
+    NSMutableArray *sourceColumns = [@[ @"__objectid"] mutableCopy];
+    NSMutableArray *destinationColumns = [@[ @"__objectid"] mutableCopy];
     [[mapping attributeMappings] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         NSExpression *expression = [obj valueExpression];
         if (expression != nil) {


### PR DESCRIPTION
We found out that CoreDatas ObjectIDs are not preserved, when running lightweight migrations (in our case: Adding an attribute), cause only mapped attributes are copied to the newly created table. This broke a to-one relationship in our database, because the stored IDs didn't match the actual IDs anymore. This lead to unfulfillable faults in our database. The solution seems pretty obvious and I'm a little unsure if I didn't miss anything. Anyway this fixed our issue and manual handling of ObjectIDs is done in other parts of the migration process as well, so this might have just been missed. Thanks for the great work!