### PR TITLE
Fix ambiguous column name error.

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -62,6 +62,9 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
 
 @property (nonatomic, readonly) long typeHash;
 
+/// Recursively returns an array of this NSEntityDescription's typeHash, along with all of its subentities'.
+@property (nonatomic, readonly) NSArray *typeHashSubhierarchy;
+
 @end
 
 @implementation EncryptedStore {
@@ -426,22 +429,21 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
                 if ([self entityNeedsEntityTypeColumn:destinationEntity]) {
                     // Get the destination table for the type look up
                     NSString *destinationTable = [self tableNameForEntity:destinationEntity];
-                    
+                    NSString *destinationAlias = [NSString stringWithFormat:@"T%lul",(unsigned long)destinationEntity.hash];
+
                     // Add teh type column to the query
-                    NSString *typeColumn = [NSString stringWithFormat:@"%@.__entityType", destinationTable];
+                    NSString *typeColumn = [NSString stringWithFormat:@"%@.__entityType", destinationAlias];
                     [columns addObject:typeColumn];
-                    
-                    // Create the join
-                    NSString *join = [NSString stringWithFormat:@" INNER JOIN %@ ON %@.__objectid=%@.%@", destinationTable, destinationTable, table, column];
-                    
-                    
+
+                    NSString *join = [NSString stringWithFormat:@" INNER JOIN %@ as %@ ON %@.__objectid=%@.%@", destinationTable, destinationAlias, destinationAlias, table, column];
+
                     // this part handles optional relationship
                     if (relationship.optional) {
                         join = [join stringByAppendingFormat:@" OR %@.%@ IS NULL", table, column];
                     }
-                    
+
                     [typeJoins addObject:join];
-                    
+
                     // Mark that this relation needs a type lookup
                     [entityTypes addObject:key];
                 }
@@ -554,13 +556,15 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
     } else {
         // one-to-many relationship, foreign key exists in desination entity table
         NSString *destinationTable = [self tableNameForEntity:destinationEntity];
-        
+
         NSString *string = [NSString stringWithFormat:
-                            @"SELECT __objectID%@ FROM %@ WHERE %@=? ORDER BY %@ ASC",
+                            @"SELECT __objectID%@ FROM %@ WHERE %@ AND %@=? ORDER BY %@ ASC",
                             shouldFetchDestinationEntityType ? @", __entityType" : @"",
                             destinationTable,
+                            [NSString stringWithFormat:@"__entityType IN %@", [destinationEntity typeHashSubhierarchy]],
                             [self foreignKeyColumnForRelationship:inverseRelationship],
                             [NSString stringWithFormat:@"%@_order", inverseRelationship.name]];
+
         statement = [self preparedStatementForQuery:string];
         sqlite3_bind_int64(statement, 1, key);
     }
@@ -3342,6 +3346,15 @@ static void dbsqliteRegExp(sqlite3_context *context, int argc, const char **argv
 {
     long hash = (long)self.name.hash;
     return hash;
+}
+
+-(NSArray *)typeHashSubhierarchy
+{
+    NSMutableArray *hashes = [NSMutableArray arrayWithObject:[NSNumber numberWithLong:self.typeHash]];
+    for (NSEntityDescription *entity in self.subentities) {
+        [hashes addObjectsFromArray: entity.typeHashSubhierarchy];
+    }
+    return hashes;
 }
 
 @end

--- a/exampleProjects/IncrementalStore/ClassModel.xcdatamodeld/ClassModel.xcdatamodel/contents
+++ b/exampleProjects/IncrementalStore/ClassModel.xcdatamodeld/ClassModel.xcdatamodel/contents
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14B25" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="14F27" minimumToolsVersion="Xcode 4.3">
     <entity name="ChildA" representedClassName="ISDChildA" parentEntity="Parent" syncable="YES">
         <attribute name="attributeA" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="multipleOneToMany" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Root" inverseName="multipleOneToManyChildA" inverseEntity="Root" syncable="YES"/>
     </entity>
     <entity name="ChildB" representedClassName="ISDChildB" parentEntity="Parent" syncable="YES">
         <attribute name="attributeB" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="multipleOneToMany" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Root" inverseName="multipleOneToManyChildB" inverseEntity="Root" syncable="YES"/>
     </entity>
     <entity name="Parent" representedClassName="ISDParent" isAbstract="YES" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
@@ -15,15 +17,17 @@
     <entity name="Root" representedClassName="ISDRoot" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="manyToMany" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Parent" inverseName="manyToManyInverse" inverseEntity="Parent" syncable="YES"/>
+        <relationship name="multipleOneToManyChildA" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChildA" inverseName="multipleOneToMany" inverseEntity="ChildA" syncable="YES"/>
+        <relationship name="multipleOneToManyChildB" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChildB" inverseName="multipleOneToMany" inverseEntity="ChildB" syncable="YES"/>
         <relationship name="oneToMany" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Parent" inverseName="oneToManyInverse" inverseEntity="Parent" syncable="YES"/>
         <relationship name="oneToOne" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Parent" inverseName="oneToOneInverse" inverseEntity="Parent" syncable="YES"/>
         <relationship name="recursiveManyToMany" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Root" inverseName="recursiveManyToManyInverse" inverseEntity="Root" syncable="YES"/>
         <relationship name="recursiveManyToManyInverse" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Root" inverseName="recursiveManyToMany" inverseEntity="Root" syncable="YES"/>
     </entity>
     <elements>
-        <element name="ChildA" positionX="-119" positionY="144" width="128" height="58"/>
-        <element name="ChildB" positionX="79" positionY="144" width="128" height="58"/>
+        <element name="ChildA" positionX="-119" positionY="144" width="128" height="75"/>
+        <element name="ChildB" positionX="79" positionY="144" width="128" height="75"/>
         <element name="Parent" positionX="-20" positionY="8" width="128" height="103"/>
-        <element name="Root" positionX="-236" positionY="8" width="128" height="133"/>
+        <element name="Root" positionX="-236" positionY="8" width="128" height="165"/>
     </elements>
 </model>

--- a/exampleProjects/IncrementalStore/ClassModels/ISDChildA.h
+++ b/exampleProjects/IncrementalStore/ClassModels/ISDChildA.h
@@ -14,5 +14,6 @@
 @interface ISDChildA : ISDParent
 
 @property (nonatomic, retain) NSString * attributeA;
+@property (nonatomic, retain) ISDRoot *multipleOneToMany;
 
 @end

--- a/exampleProjects/IncrementalStore/ClassModels/ISDChildA.m
+++ b/exampleProjects/IncrementalStore/ClassModels/ISDChildA.m
@@ -12,5 +12,6 @@
 @implementation ISDChildA
 
 @dynamic attributeA;
+@dynamic multipleOneToMany;
 
 @end

--- a/exampleProjects/IncrementalStore/ClassModels/ISDChildB.h
+++ b/exampleProjects/IncrementalStore/ClassModels/ISDChildB.h
@@ -14,5 +14,6 @@
 @interface ISDChildB : ISDParent
 
 @property (nonatomic, retain) NSString * attributeB;
+@property (nonatomic, retain) ISDRoot *multipleOneToMany;
 
 @end

--- a/exampleProjects/IncrementalStore/ClassModels/ISDChildB.m
+++ b/exampleProjects/IncrementalStore/ClassModels/ISDChildB.m
@@ -12,5 +12,6 @@
 @implementation ISDChildB
 
 @dynamic attributeB;
+@dynamic multipleOneToMany;
 
 @end

--- a/exampleProjects/IncrementalStore/ClassModels/ISDRoot.h
+++ b/exampleProjects/IncrementalStore/ClassModels/ISDRoot.h
@@ -17,6 +17,9 @@
 @property (nonatomic, retain) NSSet *oneToMany;
 @property (nonatomic, retain) ISDParent *oneToOne;
 @property (nonatomic, retain) NSSet *manyToMany;
+@property (nonatomic, retain) NSSet *multipleOneToManyChildA;
+@property (nonatomic, retain) NSSet *multipleOneToManyChildB;
+
 @end
 
 @interface ISDRoot (CoreDataGeneratedAccessors)
@@ -30,5 +33,15 @@
 - (void)removeManyToManyObject:(ISDParent *)value;
 - (void)addManyToMany:(NSSet *)values;
 - (void)removeManyToMany:(NSSet *)values;
+
+- (void)addMultipleOneToManyChildAObject:(ISDParent *)value;
+- (void)removeMultipleOneToManyChildAObject:(ISDParent *)value;
+- (void)addMultipleOneToManyChildA:(NSSet *)values;
+- (void)removeMultipleOneToManyChildA:(NSSet *)values;
+
+- (void)addMultipleOneToManyChildBObject:(ISDParent *)value;
+- (void)removeMultipleOneToManyChildBObject:(ISDParent *)value;
+- (void)addMultipleOneToManyChildB:(NSSet *)values;
+- (void)removeMultipleOneToManyChildB:(NSSet *)values;
 
 @end

--- a/exampleProjects/IncrementalStore/ClassModels/ISDRoot.m
+++ b/exampleProjects/IncrementalStore/ClassModels/ISDRoot.m
@@ -16,5 +16,7 @@
 @dynamic oneToMany;
 @dynamic oneToOne;
 @dynamic manyToMany;
+@dynamic multipleOneToManyChildA;
+@dynamic multipleOneToManyChildB;
 
 @end

--- a/exampleProjects/IncrementalStore/Incremental Store.xcodeproj/project.pbxproj
+++ b/exampleProjects/IncrementalStore/Incremental Store.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 				ORGANIZATIONNAME = "Caleb Davenport";
 				TargetAttributes = {
 					3BD5EFF415EE5DDF00333320 = {
-						DevelopmentTeam = M9BLEU3LFV;
+						DevelopmentTeam = MUDZYBY5ZE;
 					};
 					440E851019B3A1B0002542D1 = {
 						TestTargetID = 3BD5EFF415EE5DDF00333320;
@@ -490,7 +490,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-DSQLITE_HAS_CODEC";
 				SDKROOT = iphoneos;
@@ -521,7 +521,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_CFLAGS = (
 					"-DNS_BLOCK_ASSERTIONS=1",
 					"-DSQLITE_HAS_CODEC",
@@ -536,6 +536,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Incremental Store Demo/Incremental Store Demo-Prefix.pch";
 				HEADER_SEARCH_PATHS = "\"$PROJECT_DIR/../Incremental Store\"/**";
@@ -550,6 +551,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Incremental Store Demo/Incremental Store Demo-Prefix.pch";
 				HEADER_SEARCH_PATHS = "\"$PROJECT_DIR/../Incremental Store\"/**";
@@ -572,6 +574,7 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/exampleProjects/IncrementalStore/Incremental Store.xcodeproj/xcshareddata/xcschemes/Incremental Store Demo.xcscheme
+++ b/exampleProjects/IncrementalStore/Incremental Store.xcodeproj/xcshareddata/xcschemes/Incremental Store Demo.xcscheme
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,17 +48,21 @@
             ReferencedContainer = "container:Incremental Store.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3BD5EFF415EE5DDF00333320"
@@ -77,12 +81,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3BD5EFF415EE5DDF00333320"

--- a/exampleProjects/IncrementalStore/SubEntitiesModel.xcdatamodeld/SubEntitiesModel.xcdatamodel/contents
+++ b/exampleProjects/IncrementalStore/SubEntitiesModel.xcdatamodeld/SubEntitiesModel.xcdatamodel/contents
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6244" systemVersion="13F34" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="14F27" minimumToolsVersion="Xcode 4.3">
     <entity name="BaseStatusUpdate" isAbstract="YES" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <entity name="FullJob" parentEntity="Job" syncable="YES">
         <attribute name="longNumber" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <relationship name="lightweightJob" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LightweightJob" inverseName="fullJob" inverseEntity="LightweightJob" syncable="YES"/>
     </entity>
     <entity name="Job" isAbstract="YES" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <entity name="JobStatusUpdate" parentEntity="BaseStatusUpdate" syncable="YES"/>
-    <entity name="LightweightJob" parentEntity="Job" syncable="YES"/>
+    <entity name="LightweightJob" parentEntity="Job" syncable="YES">
+        <relationship name="fullJob" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="FullJob" inverseName="lightweightJob" inverseEntity="FullJob" syncable="YES"/>
+    </entity>
     <elements>
-        <element name="Job" positionX="-137" positionY="-144" width="128" height="58"/>
-        <element name="LightweightJob" positionX="-207" positionY="0" width="128" height="45"/>
-        <element name="FullJob" positionX="-63" positionY="-0" width="128" height="58"/>
         <element name="BaseStatusUpdate" positionX="106" positionY="-144" width="128" height="58"/>
-        <element name="JobStatusUpdate" positionX="106" positionY="2" width="128" height="43"/>
+        <element name="FullJob" positionX="-63" positionY="-0" width="128" height="75"/>
+        <element name="Job" positionX="-137" positionY="-144" width="128" height="58"/>
+        <element name="JobStatusUpdate" positionX="106" positionY="2" width="128" height="45"/>
+        <element name="LightweightJob" positionX="-207" positionY="0" width="128" height="60"/>
     </elements>
 </model>


### PR DESCRIPTION
Also fix issue with not specifying the entity type for a relationship.


The first bug solved by this commit adds an alias when joining tables, so that if two sibling tables are joined, they do not have duplicate columns.

The second bug is caused when you have two entities that have the same named relation to a different entity (say, `A` and `B` both have a `C` relation). When querying for `C.A`, the generated SQL query was returning all entities that had the relation to that instance of `C`, rather than just the `A` entities. This is solved by adding entity types to the `WHERE` clause when fetching a relationship. Currently only implemented on the to-many code branch, but it may be necessary for many-many and to-one branches as well.