### PR TITLE
Filter out database passphrase and location information from database file attributes

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -115,7 +115,10 @@ static NSString * const EncryptedStoreMetadataTableName = @"meta";
     
     if (databaseURL)
     {
-        [[NSFileManager defaultManager] setAttributes:options ofItemAtPath:[databaseURL absoluteString] error:nil];
+        NSMutableDictionary *fileAttributes = [options mutableCopy];
+        [fileAttributes removeObjectsForKeys:@[EncryptedStorePassphraseKey, EncryptedStoreDatabaseLocation]];
+        
+        [[NSFileManager defaultManager] setAttributes:[fileAttributes copy] ofItemAtPath:[databaseURL absoluteString] error:nil];
     }
     
     if (backup){


### PR DESCRIPTION
In order to make library secure, I would limit the amount of places we expose database passphrase to external environment. Since in `makeStoreWithOptions:managedObjectModel:error` we use `options` for both, os-level file attributes and a mechanism for passing a passphrase for db encryption, I suggest removing passphrase (and file path) information from attributes set on database file.

It is not security issue, since `-NSFileManager:setAttributes:ofItemAtPath:error` has predefined keys that can be used as file attributes and ignores other, but I find it a good practise not to expose such a critical information as passphrase, when not necessary.