### PR TITLE
Fix to one relationship entity table join for entity type

### DIFF
--- a/exampleProjects/IncrementalStore/ClassModel.xcdatamodeld/ClassModel.xcdatamodel/contents
+++ b/exampleProjects/IncrementalStore/ClassModel.xcdatamodeld/ClassModel.xcdatamodel/contents
@@ -13,6 +13,7 @@
         <relationship name="manyToManyInverse" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Root" inverseName="manyToMany" inverseEntity="Root" syncable="YES"/>
         <relationship name="oneToManyInverse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Root" inverseName="oneToMany" inverseEntity="Root" syncable="YES"/>
         <relationship name="oneToOneInverse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Root" inverseName="oneToOne" inverseEntity="Root" syncable="YES"/>
+        <relationship name="oneToOneNilInverse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Root" inverseName="oneToOneNil" inverseEntity="Root" syncable="YES"/>
     </entity>
     <entity name="Root" representedClassName="ISDRoot" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
@@ -21,13 +22,14 @@
         <relationship name="multipleOneToManyChildB" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChildB" inverseName="multipleOneToMany" inverseEntity="ChildB" syncable="YES"/>
         <relationship name="oneToMany" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Parent" inverseName="oneToManyInverse" inverseEntity="Parent" syncable="YES"/>
         <relationship name="oneToOne" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Parent" inverseName="oneToOneInverse" inverseEntity="Parent" syncable="YES"/>
+        <relationship name="oneToOneNil" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Parent" inverseName="oneToOneNilInverse" inverseEntity="Parent" syncable="YES"/>
         <relationship name="recursiveManyToMany" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Root" inverseName="recursiveManyToManyInverse" inverseEntity="Root" syncable="YES"/>
         <relationship name="recursiveManyToManyInverse" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Root" inverseName="recursiveManyToMany" inverseEntity="Root" syncable="YES"/>
     </entity>
     <elements>
         <element name="ChildA" positionX="-119" positionY="144" width="128" height="75"/>
         <element name="ChildB" positionX="79" positionY="144" width="128" height="75"/>
-        <element name="Parent" positionX="-20" positionY="8" width="128" height="103"/>
-        <element name="Root" positionX="-236" positionY="8" width="128" height="165"/>
+        <element name="Parent" positionX="-20" positionY="8" width="128" height="120"/>
+        <element name="Root" positionX="-236" positionY="8" width="128" height="180"/>
     </elements>
 </model>

--- a/exampleProjects/IncrementalStore/ClassModels/ISDParent.h
+++ b/exampleProjects/IncrementalStore/ClassModels/ISDParent.h
@@ -16,6 +16,7 @@
 @property (nonatomic, retain) NSString * name;
 @property (nonatomic, retain) ISDRoot *oneToManyInverse;
 @property (nonatomic, retain) ISDRoot *oneToOneInverse;
+@property (nonatomic, retain) ISDRoot *oneToOneNilInverse;
 @property (nonatomic, retain) NSSet *manyToManyInverse;
 @end
 

--- a/exampleProjects/IncrementalStore/ClassModels/ISDParent.m
+++ b/exampleProjects/IncrementalStore/ClassModels/ISDParent.m
@@ -15,6 +15,7 @@
 @dynamic name;
 @dynamic oneToManyInverse;
 @dynamic oneToOneInverse;
+@dynamic oneToOneNilInverse;
 @dynamic manyToManyInverse;
 
 @end

--- a/exampleProjects/IncrementalStore/ClassModels/ISDRoot.h
+++ b/exampleProjects/IncrementalStore/ClassModels/ISDRoot.h
@@ -16,6 +16,7 @@
 @property (nonatomic, retain) NSString * name;
 @property (nonatomic, retain) NSSet *oneToMany;
 @property (nonatomic, retain) ISDParent *oneToOne;
+@property (nonatomic, retain) ISDParent *oneToOneNil;
 @property (nonatomic, retain) NSSet *manyToMany;
 @property (nonatomic, retain) NSSet *multipleOneToManyChildA;
 @property (nonatomic, retain) NSSet *multipleOneToManyChildB;

--- a/exampleProjects/IncrementalStore/ClassModels/ISDRoot.m
+++ b/exampleProjects/IncrementalStore/ClassModels/ISDRoot.m
@@ -15,6 +15,7 @@
 @dynamic name;
 @dynamic oneToMany;
 @dynamic oneToOne;
+@dynamic oneToOneNil;
 @dynamic manyToMany;
 @dynamic multipleOneToManyChildA;
 @dynamic multipleOneToManyChildB;

--- a/exampleProjects/IncrementalStore/Tests/RelationTests.m
+++ b/exampleProjects/IncrementalStore/Tests/RelationTests.m
@@ -309,6 +309,20 @@
     [self checkOneToOneWithChildA:YES childB:NO];
 }
 
+-(void)testFetchingOneToOneNilFromCache
+{
+    [self checkOneToOneNil];
+}
+
+-(void)testFetchingOneToOneNilFromDatabase
+{
+    // Make sure we're loading directly from DB
+    [self resetCoordinator];
+    [self createCoordinator];
+    
+    [self checkOneToOneNil];
+}
+
 -(void)testFetchingManyToManyFromCache
 {
     [self checkManyToManyWithChildACount:2 childBCount:3];
@@ -380,6 +394,12 @@
         XCTAssertTrue([child isKindOfClass:[ISDChildB class]], @"One-to-one child is of wrong class, got: %@, expecting: %@", NSStringFromClass([child class]), NSStringFromClass([ISDChildB class]));
         XCTAssertFalse([child isKindOfClass:[ISDChildA class]], @"One-to-one child is of wrong class, got: %@, expecting: %@", NSStringFromClass([child class]), NSStringFromClass([ISDChildB class]));
     }
+}
+  
+-(void)checkOneToOneNil
+{
+    ISDRoot *fetchedRoot = [self fetchRootObject];
+    XCTAssert(fetchedRoot.oneToOneNil == nil, @"We didn't set it, should be nil");
 }
 
 /// Checks that the root object has the correct number of many-to-many relational ChildA and ChildB objects


### PR DESCRIPTION
When you have multiple to-one relationship to entity that needs entity type and entity names are the same, current way of forming table alias for join forms same aliases. I updated test model and added a test for relationships. To fix it I changed table alias forming to just use 't' + incremented integer.
There is also a problem with the way optional to-one relationships are handled, with "OR table.column IS NULL" added to INNER JOIN predicate you can get multiple rows formed with the same row from left table and different rows from right table. It currently works because we just take the first row after executing query and check relationship's object id from left table, but it's not good. The correct way here is to use LEFT JOIN.