### PR TITLE
Concurrency issue [reproduced through tests]

### DIFF
--- a/exampleProjects/IncrementalStore/Incremental Store.xcodeproj/project.pbxproj
+++ b/exampleProjects/IncrementalStore/Incremental Store.xcodeproj/project.pbxproj
@@ -40,6 +40,10 @@
 		65CE88581C2940E3006478BC /* ISDMigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 65CE88571C2940E3006478BC /* ISDMigrationTests.m */; };
 		65CE885F1C29443E006478BC /* Migration.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 65CE885C1C29443E006478BC /* Migration.xcdatamodeld */; };
 		661D95AF1954821900581737 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 661D95AE1954821900581737 /* Security.framework */; };
+		66418E761D2BB93000546D5B /* ConcurrencyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 66418E751D2BB93000546D5B /* ConcurrencyTests.m */; };
+		66418E8A1D2BBDDD00546D5B /* SingleDefaultStoreManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 66418E861D2BBDDD00546D5B /* SingleDefaultStoreManager.m */; };
+		66418E8B1D2BBDDD00546D5B /* SingleEncryptedStoreManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 66418E891D2BBDDD00546D5B /* SingleEncryptedStoreManager.m */; };
+		66418E951D2C19D000546D5B /* DoubleEncryptedStoreManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 66418E941D2C19D000546D5B /* DoubleEncryptedStoreManager.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -116,6 +120,14 @@
 		65CE885E1C29443E006478BC /* New.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = New.xcdatamodel; sourceTree = "<group>"; };
 		65CE88601C295448006478BC /* New.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = New.xcdatamodel; sourceTree = "<group>"; };
 		661D95AE1954821900581737 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		66418E751D2BB93000546D5B /* ConcurrencyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConcurrencyTests.m; sourceTree = "<group>"; };
+		66418E851D2BBDDD00546D5B /* SingleDefaultStoreManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingleDefaultStoreManager.h; sourceTree = "<group>"; };
+		66418E861D2BBDDD00546D5B /* SingleDefaultStoreManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SingleDefaultStoreManager.m; sourceTree = "<group>"; };
+		66418E871D2BBDDD00546D5B /* PersistenceManagerDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PersistenceManagerDelegate.h; sourceTree = "<group>"; };
+		66418E881D2BBDDD00546D5B /* SingleEncryptedStoreManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingleEncryptedStoreManager.h; sourceTree = "<group>"; };
+		66418E891D2BBDDD00546D5B /* SingleEncryptedStoreManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SingleEncryptedStoreManager.m; sourceTree = "<group>"; };
+		66418E931D2C19D000546D5B /* DoubleEncryptedStoreManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DoubleEncryptedStoreManager.h; sourceTree = "<group>"; };
+		66418E941D2C19D000546D5B /* DoubleEncryptedStoreManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DoubleEncryptedStoreManager.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -242,12 +254,14 @@
 		440E851519B3A1B0002542D1 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				66418E841D2BBD9000546D5B /* Concurrency Helpers */,
 				440E852319B3A1E1002542D1 /* IncrementalStoreTests.m */,
 				440E852419B3A1E1002542D1 /* PasswordTests.m */,
 				440E852519B3A1E1002542D1 /* RelationTests.m */,
 				440B67DC19D1E52100C28112 /* SubEntityTests.m */,
 				65CE88571C2940E3006478BC /* ISDMigrationTests.m */,
 				440E851619B3A1B0002542D1 /* Supporting Files */,
+				66418E751D2BB93000546D5B /* ConcurrencyTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -277,6 +291,20 @@
 				444AF95219B3814500B1F2A1 /* ISDModelCategories.m */,
 			);
 			path = ClassModels;
+			sourceTree = "<group>";
+		};
+		66418E841D2BBD9000546D5B /* Concurrency Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				66418E851D2BBDDD00546D5B /* SingleDefaultStoreManager.h */,
+				66418E861D2BBDDD00546D5B /* SingleDefaultStoreManager.m */,
+				66418E871D2BBDDD00546D5B /* PersistenceManagerDelegate.h */,
+				66418E881D2BBDDD00546D5B /* SingleEncryptedStoreManager.h */,
+				66418E891D2BBDDD00546D5B /* SingleEncryptedStoreManager.m */,
+				66418E931D2C19D000546D5B /* DoubleEncryptedStoreManager.h */,
+				66418E941D2C19D000546D5B /* DoubleEncryptedStoreManager.m */,
+			);
+			path = "Concurrency Helpers";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -420,8 +448,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				65CE88581C2940E3006478BC /* ISDMigrationTests.m in Sources */,
+				66418E951D2C19D000546D5B /* DoubleEncryptedStoreManager.m in Sources */,
+				66418E8B1D2BBDDD00546D5B /* SingleEncryptedStoreManager.m in Sources */,
 				440E852719B3A1E1002542D1 /* PasswordTests.m in Sources */,
+				66418E8A1D2BBDDD00546D5B /* SingleDefaultStoreManager.m in Sources */,
 				440B67DD19D1E52100C28112 /* SubEntityTests.m in Sources */,
+				66418E761D2BB93000546D5B /* ConcurrencyTests.m in Sources */,
 				440E852619B3A1E1002542D1 /* IncrementalStoreTests.m in Sources */,
 				440E852819B3A1E1002542D1 /* RelationTests.m in Sources */,
 			);

--- a/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/DoubleEncryptedStoreManager.h
+++ b/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/DoubleEncryptedStoreManager.h
@@ -1,0 +1,13 @@
+//
+//  DoubleEncryptedStoreManager.h
+//  Incremental Store
+//
+//  Created by Nacho on 5/7/16.
+//  Copyright © 2016 Caleb Davenport. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SingleEncryptedStoreManager.h"
+
+@interface DoubleEncryptedStoreManager : SingleEncryptedStoreManager
+@end

--- a/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/DoubleEncryptedStoreManager.m
+++ b/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/DoubleEncryptedStoreManager.m
@@ -1,0 +1,58 @@
+//
+//  DoubleEncryptedStoreManager.m
+//  Incremental Store
+//
+//  Created by Nacho on 5/7/16.
+//  Copyright © 2016 Caleb Davenport. All rights reserved.
+//
+
+#import "DoubleEncryptedStoreManager.h"
+
+@interface DoubleEncryptedStoreManager ()
+@property (readonly, strong, nonatomic) NSPersistentStoreCoordinator *privatePersistentStoreCoordinator;
+@end
+
+@implementation DoubleEncryptedStoreManager
+
+@synthesize privatePersistentStoreCoordinator = _privatePersistentStoreCoordinator;
+@synthesize privateContext = _privateContext;
+
+- (NSPersistentStoreCoordinator *)privatePersistentStoreCoordinator
+{
+  // The persistent store coordinator for the application. This implementation creates and returns a coordinator, having added the store for the application to it.
+  if (_privatePersistentStoreCoordinator != nil) {
+    return _privatePersistentStoreCoordinator;
+  }
+  
+  // Create the coordinator and store
+  NSError *error = nil;
+  _privatePersistentStoreCoordinator = [self createPersistentStoreCoordinator:&error];
+  NSAssert(_privatePersistentStoreCoordinator, @"Unable to add persistent store: %@", error);
+  
+  return _privatePersistentStoreCoordinator;
+}
+
+- (NSManagedObjectContext *)privateContext
+{
+  if (_privateContext != nil) {
+    return _privateContext;
+  }
+  
+  NSPersistentStoreCoordinator *coordinator = [self privatePersistentStoreCoordinator];
+  if (!coordinator) {
+    return nil;
+  }
+  
+  _privateContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
+  [_privateContext setPersistentStoreCoordinator:coordinator];
+  _privateContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy;
+  
+  return _privateContext;
+}
+
+- (void)contextDidSaveMainContext:(NSNotification *)notification
+{
+  // Ignore this notification
+}
+
+@end

--- a/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/PersistenceManagerDelegate.h
+++ b/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/PersistenceManagerDelegate.h
@@ -1,0 +1,14 @@
+//
+// Created by Nacho on 4/7/16.
+// Copyright (c) 2016 Ignacio Delgado. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@protocol PersistenceManagerDelegate <NSObject>
+@property (nonatomic, strong) NSManagedObjectContext *mainContext;
+@property (nonatomic, strong) NSManagedObjectContext *privateContext;
+- (void)saveContext:(NSManagedObjectContext *)context;
++ (void)deleteDatabase;
+@end

--- a/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/SingleDefaultStoreManager.h
+++ b/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/SingleDefaultStoreManager.h
@@ -1,0 +1,16 @@
+//
+//  SingleDefaultStoreManager.h
+//  Incremental Store
+//
+//  Created by Nacho on 5/7/16.
+//  Copyright © 2016 Ignacio Delgado. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "PersistenceManagerDelegate.h"
+
+@interface SingleDefaultStoreManager : NSObject <PersistenceManagerDelegate>
+@property (readonly, strong, nonatomic) NSManagedObjectModel *managedObjectModel;
++ (NSURL *)applicationDocumentsDirectory;
+- (NSPersistentStoreCoordinator *)createPersistentStoreCoordinator:(__autoreleasing NSError **)error;
+@end

--- a/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/SingleDefaultStoreManager.m
+++ b/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/SingleDefaultStoreManager.m
@@ -1,0 +1,180 @@
+//
+//  SingleDefaultStoreManager.m
+//  Incremental Store
+//
+//  Created by Nacho on 5/7/16.
+//  Copyright © 2016 Ignacio Delgado. All rights reserved.
+//
+
+#import "SingleDefaultStoreManager.h"
+#import <CoreData/CoreData.h>
+#import "EncryptedStore.h"
+
+@interface SingleDefaultStoreManager ()
+@property (nonatomic, strong) NSManagedObjectContext *persistentContext;
+@property (readonly, strong, nonatomic) NSPersistentStoreCoordinator *persistentStoreCoordinator;
+@end
+
+@implementation SingleDefaultStoreManager
+
+#pragma mark - Core Data stack
+
+@synthesize managedObjectModel = _managedObjectModel;
+@synthesize persistentStoreCoordinator = _persistentStoreCoordinator;
+@synthesize persistentContext = _persistentContext;
+@synthesize mainContext = _mainContext;
+@synthesize privateContext = _privateContext;
+
+- (instancetype)init
+{
+  self =[super init];
+  if (self){
+    [self mainContext];
+    [self privateContext];
+  }
+  return self;
+}
+
++ (NSURL *)applicationDocumentsDirectory
+{
+  NSURL *result = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+  return result;
+}
+
++ (NSURL *)databaseURL
+{
+  return [[self applicationDocumentsDirectory] URLByAppendingPathComponent:@"Concurrency.sqlite"];
+}
+
+- (NSManagedObjectModel *)managedObjectModel
+{
+  // The managed object model for the application. It is a fatal error for the application not to be able to find and load its model.
+  if (_managedObjectModel != nil) {
+    return _managedObjectModel;
+  }
+  NSURL *modelURL = [[NSBundle bundleForClass:[EncryptedStore class]] URLForResource:@"ClassModel" withExtension:@"momd"];
+  _managedObjectModel = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
+  return _managedObjectModel;
+}
+
+- (NSPersistentStoreCoordinator *)persistentStoreCoordinator
+{
+  // The persistent store coordinator for the application. This implementation creates and returns a coordinator, having added the store for the application to it.
+  if (_persistentStoreCoordinator != nil) {
+    return _persistentStoreCoordinator;
+  }
+  
+  // Create the coordinator and store
+  NSError *error = nil;
+  _persistentStoreCoordinator = [self createPersistentStoreCoordinator:&error];
+  NSAssert(_persistentStoreCoordinator, @"Unable to add persistent store: %@", error);
+  
+  return _persistentStoreCoordinator;
+}
+
+- (NSPersistentStoreCoordinator *)createPersistentStoreCoordinator:(__autoreleasing NSError **)error
+{
+  NSPersistentStoreCoordinator *result = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:self.managedObjectModel];
+  
+  if (![result addPersistentStoreWithType:NSSQLiteStoreType
+                            configuration:nil
+                                      URL:[[self class] databaseURL]
+                                  options:@{
+                                            NSSQLitePragmasOption: @{@"journal_mode":@"DELETE"}
+                                            }
+                                    error:error]) {
+    return nil;
+  }else{
+    return result;
+  }
+}
+
+- (NSManagedObjectContext *)persistentContext
+{
+  if (_persistentContext != nil) {
+    return _persistentContext;
+  }
+  
+  NSPersistentStoreCoordinator *coordinator = [self persistentStoreCoordinator];
+  if (!coordinator) {
+    return nil;
+  }
+  
+  _persistentContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
+  [_persistentContext setPersistentStoreCoordinator:coordinator];
+  _persistentContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy;
+  
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(contextDidSavePersistentContext:)
+                                               name:NSManagedObjectContextDidSaveNotification
+                                             object:_persistentContext];
+  return _persistentContext;
+}
+
+- (NSManagedObjectContext *)mainContext
+{
+  if (_mainContext != nil) {
+    return _mainContext;
+  }
+  _mainContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+  [_mainContext setParentContext:self.persistentContext];
+  
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(contextDidSaveMainContext:)
+                                               name:NSManagedObjectContextDidSaveNotification
+                                             object:_mainContext];
+  return _mainContext;
+}
+
+- (NSManagedObjectContext *)privateContext
+{
+  if (_privateContext != nil) {
+    return _privateContext;
+  }
+  _privateContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
+  [_privateContext setParentContext:self.persistentContext];
+  return _privateContext;
+}
+
+#pragma mark - Core Data Saving support
+
+- (void)saveContext:(NSManagedObjectContext *)managedObjectContext
+{
+  if (managedObjectContext != nil) {
+    __block NSError *error = nil;
+    if ([managedObjectContext hasChanges] && ![managedObjectContext save:&error]) {
+      NSAssert(NO, @"Unresolved error %@, %@", error, [error userInfo]);
+    } else if (managedObjectContext.parentContext) { //If there is a parent context, chain up the save
+      [managedObjectContext.parentContext performBlock:^{
+        [managedObjectContext.parentContext save:nil];
+      }];
+    }
+  }
+}
+
+- (void)contextDidSaveMainContext:(NSNotification *)notification
+{
+  [self.privateContext performBlock:^{
+    [self.privateContext mergeChangesFromContextDidSaveNotification:notification];
+  }];
+}
+
+- (void)contextDidSavePersistentContext:(NSNotification *)notification
+{
+  // We want to propagate the final ObjectIDs to the main context as soon as possible
+  if (((NSSet *)notification.userInfo[NSInsertedObjectsKey]).count > 0 || ((NSSet *)notification.userInfo[NSUpdatedObjectsKey]).count > 0) {
+    NSError *error = nil;
+    if (![self.mainContext obtainPermanentIDsForObjects:_mainContext.registeredObjects.allObjects error:&error]) {
+      NSAssert(NO, @"Error refreshing temporary ObjectID in main context - %@ - %@ -", error, error.userInfo);
+    }
+  }
+}
+
+#pragma mark - Helper methods
+
++ (void)deleteDatabase
+{
+  [[NSFileManager defaultManager] removeItemAtURL:[self databaseURL] error:nil];
+}
+
+@end

--- a/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/SingleEncryptedStoreManager.h
+++ b/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/SingleEncryptedStoreManager.h
@@ -1,0 +1,13 @@
+//
+//  SingleEncryptedStoreManager.h
+//  Incremental Store
+//
+//  Created by Nacho on 5/7/16.
+//  Copyright © 2016 Ignacio Delgado. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SingleDefaultStoreManager.h"
+
+@interface SingleEncryptedStoreManager : SingleDefaultStoreManager
+@end

--- a/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/SingleEncryptedStoreManager.m
+++ b/exampleProjects/IncrementalStore/Tests/Concurrency Helpers/SingleEncryptedStoreManager.m
@@ -1,0 +1,33 @@
+//
+//  SingleEncryptedStoreManager.m
+//  Incremental Store
+//
+//  Created by Nacho on 5/7/16.
+//  Copyright © 2016 Ignacio Delgado. All rights reserved.
+//
+
+#import "EncryptedStore.h"
+#import "SingleEncryptedStoreManager.h"
+
+@implementation SingleEncryptedStoreManager
+
++ (NSURL *)databaseURL
+{
+  return [[self applicationDocumentsDirectory] URLByAppendingPathComponent:@"ConcurrencyEncrypted.sqlite"];
+}
+
+- (NSPersistentStoreCoordinator *)createPersistentStoreCoordinator:(__autoreleasing NSError **)error
+{
+  return [EncryptedStore makeStoreWithOptions:@{
+                                                EncryptedStoreType : NSSQLiteStoreType,
+                                                EncryptedStorePassphraseKey : @"129837/asg$",
+                                                EncryptedStoreDatabaseLocation : [[self class] databaseURL],
+                                                NSInferMappingModelAutomaticallyOption : @YES,
+                                                NSMigratePersistentStoresAutomaticallyOption : @YES,
+                                                NSSQLitePragmasOption : @{@"synchronous" : @"OFF"}
+                                                }
+                           managedObjectModel:self.managedObjectModel
+                                        error:error];
+}
+
+@end

--- a/exampleProjects/IncrementalStore/Tests/ConcurrencyTests.m
+++ b/exampleProjects/IncrementalStore/Tests/ConcurrencyTests.m
@@ -1,0 +1,286 @@
+//
+//  ConcurrencyTests.m
+//  Incremental Store
+//
+//  Created by Nacho on 5/7/16.
+//  Copyright © 2016 Caleb Davenport. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "SingleDefaultStoreManager.h"
+#import "SingleEncryptedStoreManager.h"
+#import "DoubleEncryptedStoreManager.h"
+#import "ISDChildA.h"
+#import "ISDRoot.h"
+
+#pragma mark - Helper Categories
+
+@interface NSManagedObject (IDHelper)
++ (instancetype)findFirstByAttribute:(NSString *)attribute withValue:(id)value inContext:(NSManagedObjectContext *)context;
++ (instancetype)insert:(NSManagedObjectContext *)context;
++ (NSArray *)allObjectsInContext:(NSManagedObjectContext *)context;
+@end
+@implementation NSManagedObject (IDHelper)
++ (instancetype)findFirstByAttribute:(NSString *)attribute withValue:(id)value inContext:(NSManagedObjectContext *)context
+{
+  NSPredicate *searchByAttValue = [NSPredicate predicateWithFormat:@"%K = %@", attribute, value];
+  NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:[self entityName]];
+  fetchRequest.predicate = searchByAttValue;
+  fetchRequest.fetchLimit = 1;
+  NSArray *result = [context executeFetchRequest:fetchRequest error:nil];
+  return [result firstObject];
+}
+
++ (instancetype)insert:(NSManagedObjectContext *)context
+{
+  return [[NSManagedObject alloc] initWithEntity:[self entityDescriptor:context] insertIntoManagedObjectContext:context];
+}
+
++ (NSArray *)allObjectsInContext:(NSManagedObjectContext *)context
+{
+  NSFetchRequest * fetchRequest = [NSFetchRequest fetchRequestWithEntityName:[self entityName]];
+  return [context executeFetchRequest:fetchRequest error:nil];
+}
+
+#pragma mark Private methods
+
++ (NSString *)entityName
+{
+  return [NSStringFromClass(self) stringByReplacingOccurrencesOfString:@"ISD" withString:@""];
+}
+
++ (NSEntityDescription *)entityDescriptor:(NSManagedObjectContext *)context
+{
+  return [NSEntityDescription entityForName:[self entityName] inManagedObjectContext:context];
+}
+@end
+
+@interface ISDChildA (IDHelper)
++ (instancetype)createOrUpdateWithAttributeA:(NSString *)attributeA inContext:(NSManagedObjectContext *)context;
+@end
+@implementation ISDChildA (IDHelper)
++ (instancetype)createOrUpdateWithAttributeA:(NSString *)attributeA inContext:(NSManagedObjectContext *)context
+{
+  ISDChildA *result = [ISDChildA findFirstByAttribute:@"attributeA" withValue:attributeA inContext:context];
+  if (!result){
+    result = [ISDChildA insert:context];
+  }
+  result.attributeA = [attributeA copy];
+  return result;
+}
+@end
+
+@interface ISDRoot (IDHelper)
++ (instancetype)createOrUpdateWithName:(NSString *)name manyToMany:(NSSet *)manyToMany inContext:(NSManagedObjectContext *)context;
+@end
+@implementation ISDRoot (IDHelper)
++ (instancetype)createOrUpdateWithName:(NSString *)name manyToMany:(NSSet *)manyToMany inContext:(NSManagedObjectContext *)context
+{
+  ISDRoot *result = [ISDRoot findFirstByAttribute:@"name" withValue:name inContext:context];
+  if (!result){
+    result = [ISDRoot insert:context];
+  }
+  result.name = [name copy];
+  result.manyToMany = [manyToMany copy];
+  return result;
+}
+@end
+
+#pragma mark - Tests
+
+@interface ConcurrencyTests : XCTestCase
+@end
+
+@implementation ConcurrencyTests {
+  id<PersistenceManagerDelegate> persistenceManager;
+  NSTimer *timer;
+  NSFetchedResultsController *fetchedResultsController;
+}
+
+- (void)setUp
+{
+  [super setUp];
+  [SingleDefaultStoreManager deleteDatabase];
+  [SingleEncryptedStoreManager deleteDatabase];
+  persistenceManager = nil;
+}
+
+- (void)tearDown
+{
+  persistenceManager = nil;
+  [timer invalidate];
+  timer = nil;
+  [super tearDown];
+}
+
+- (void)testConcurrentInsertOperationsOnDefaultStore
+{
+  persistenceManager = [SingleDefaultStoreManager new];
+  [self doTestConcurrentInsertOperations];
+}
+
+- (void)testConcurrentUpdateOperationsOnDefaultStore
+{
+  persistenceManager = [SingleDefaultStoreManager new];
+  [self doTestConcurrentUpdateOperations];
+}
+
+- (void)testConcurrentInsertOperationsOnDoubleEncryptedStore
+{
+  persistenceManager = [DoubleEncryptedStoreManager new];
+  [self doTestConcurrentInsertOperations];
+}
+
+- (void)testConcurrentUpdateOperationsOnDoubleEncryptedStore
+{
+  persistenceManager = [DoubleEncryptedStoreManager new];
+  [self doTestConcurrentUpdateOperations];
+}
+
+- (void)testConcurrentInsertOperationsOnEncryptedStore
+{
+  persistenceManager = [SingleEncryptedStoreManager new];
+  [self doTestConcurrentInsertOperations];
+}
+
+- (void)testConcurrentUpdateOperationsOnEncryptedStore
+{
+  persistenceManager = [SingleEncryptedStoreManager new];
+  [self doTestConcurrentUpdateOperations];
+}
+
+#pragma mark - Helper methods
+
+- (void)createOrUpdateChildAObjectsInContext:(NSManagedObjectContext *)context sync:(BOOL)sync expectation:(XCTestExpectation *)expectation
+{
+  void (^createOrUpdateChildAObjects)() = ^(){
+    for (NSInteger count = 0; count < 20; ++count){
+      [ISDChildA createOrUpdateWithAttributeA:[NSString stringWithFormat:@"ChildA %ld", (long)count+1] inContext:context];
+    }
+    [persistenceManager saveContext:context];
+    if (expectation){
+      [expectation fulfill];
+    }
+  };
+  if (sync){
+    [context performBlockAndWait:^{
+      createOrUpdateChildAObjects();
+    }];
+  }else{
+    [context performBlock:^{
+      createOrUpdateChildAObjects();
+    }];
+  }
+}
+
+- (void)createOrUpdateRootObjectsInContext:(NSManagedObjectContext *)context sync:(BOOL)sync expectation:(XCTestExpectation *)expectation
+{
+  void (^createOrUpdateRootObjects)() = ^(){
+    NSDate *initDate = [NSDate date];
+    NSArray *allChildA = [ISDChildA allObjectsInContext:context];
+    for (NSInteger count = 0; count < 500; ++count){
+      // Randomly assign 0-3 ChildA objects to the Root object
+      NSInteger numChildsToAssign = arc4random_uniform(4);
+      NSMutableArray *childs = [@[] mutableCopy];
+      for (NSInteger i = 0; i < numChildsToAssign; ++i){
+        [childs addObject:((ISDChildA *)allChildA[arc4random_uniform((uint)allChildA.count)]).attributeA];
+      }
+      [ISDRoot createOrUpdateWithName:[NSString stringWithFormat:@"Root %ld", (long) count]
+                                manyToMany:[NSSet setWithArray:[allChildA filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"attributeA IN %@", childs]]]
+                            inContext:context];
+      if (count%100 == 0){
+        [persistenceManager saveContext:context];
+      }
+    }
+    [persistenceManager saveContext:context];
+    NSTimeInterval elapsedTime = [[NSDate date] timeIntervalSinceDate:initDate];
+    NSLog(@"Time required to insert|update Root objects: %fs", elapsedTime);
+    if (expectation){
+      [expectation fulfill];
+    }
+  };
+  if (sync){
+    [context performBlockAndWait:^{
+      createOrUpdateRootObjects();
+    }];
+  }else{
+    [context performBlock:^{
+      createOrUpdateRootObjects();
+    }];
+  }
+}
+
+- (void)initializeFetchedResultsControllerInContext:(NSManagedObjectContext *)context
+{
+  NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"Root"];
+  NSSortDescriptor *nameSort = [NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES];
+  [request setSortDescriptors:@[nameSort]];
+  
+  fetchedResultsController = [[NSFetchedResultsController alloc] initWithFetchRequest:request managedObjectContext:context sectionNameKeyPath:@"name" cacheName:nil];
+  
+  timer = [NSTimer scheduledTimerWithTimeInterval:0.25 target:self selector:@selector(doFetch) userInfo:nil repeats:YES];
+}
+
+- (void)doFetch
+{
+  NSError *error = nil;
+  BOOL result = [fetchedResultsController performFetch:&error];
+  XCTAssert(result, @"Error fetching results\n%@, %@", error, error.userInfo);
+}
+
+- (void)doTestConcurrentInsertOperations
+{
+  // Check Core Data stack model is empty
+  NSUInteger rootObjects = [ISDRoot allObjectsInContext:persistenceManager.mainContext].count;
+  XCTAssert(rootObjects == 0, @"There shouldn't be any Root objects, but there are %ld", rootObjects);
+  NSUInteger childAObjects = [ISDChildA allObjectsInContext:persistenceManager.mainContext].count;
+  XCTAssert(childAObjects == 0, @"There shouldn't be any ChildA objects, but there are %ld", childAObjects);
+  
+  // Initialize fetched results controller
+  [self initializeFetchedResultsControllerInContext:persistenceManager.mainContext];
+  
+  // Create ChildA objects
+  [self createOrUpdateChildAObjectsInContext:persistenceManager.mainContext sync:YES expectation:nil];
+  [persistenceManager.privateContext reset];
+  XCTAssert([ISDChildA allObjectsInContext:persistenceManager.mainContext].count == 20, @"There shouldn be 20 ChildA objects reachable from main context");
+  
+  // Create Root objects
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Create or Update Root objects finishes"];
+  [self createOrUpdateRootObjectsInContext:persistenceManager.privateContext sync:NO expectation:expectation];
+  [self waitForExpectationsWithTimeout:10.0 handler:^(NSError *error) {
+    XCTAssert(!error, @"Expectation returned with error - %@", error);
+  }];
+}
+
+- (void)doTestConcurrentUpdateOperations
+{
+  // Check Core Data stack model is empty
+  NSUInteger rootObjects = [ISDRoot allObjectsInContext:persistenceManager.mainContext].count;
+  XCTAssert(rootObjects == 0, @"There shouldn't be any Root objects, but there are %ld", rootObjects);
+  NSUInteger childAObjects = [ISDChildA allObjectsInContext:persistenceManager.mainContext].count;
+  XCTAssert(childAObjects == 0, @"There shouldn't be any ChildA objects, but there are %ld", childAObjects);
+  
+  // Create ChildA objects
+  [self createOrUpdateChildAObjectsInContext:persistenceManager.mainContext sync:YES expectation:nil];
+  [persistenceManager.privateContext reset];
+  XCTAssert([ISDChildA allObjectsInContext:persistenceManager.mainContext].count == 20, @"There shouldn be 20 ChildA objects reachable from main context");
+  
+  // Create Root objects
+  [self createOrUpdateRootObjectsInContext:persistenceManager.mainContext sync:YES expectation:nil];
+  [persistenceManager.privateContext reset];
+  XCTAssert([ISDRoot allObjectsInContext:persistenceManager.mainContext].count == 500, @"There shouldn be 500 Root objects reachable from main context");
+  
+  // Initialize fetched results controller
+  [self initializeFetchedResultsControllerInContext:persistenceManager.mainContext];
+  
+  // Update Root objects
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Create or Update Root objects finishes"];
+  [self createOrUpdateRootObjectsInContext:persistenceManager.privateContext sync:NO expectation:expectation];
+  [self waitForExpectationsWithTimeout:10.0 handler:^(NSError *error) {
+    XCTAssert(!error, @"Expectation returned with error - %@", error);
+    [self doFetch];
+    XCTAssert(fetchedResultsController.fetchedObjects.count == 500, @"There should be 500 Root objects after finishing processing updates, but there are %ld", fetchedResultsController.fetchedObjects.count);
+  }];
+}
+
+@end


### PR DESCRIPTION
## Description

I am currently using Encrypted Core Data in a project, and I am experiencing a concurrency issue.

My project has a Core Data Stack like this one
![1-6ufmw_viglltpujlfqnkjg](https://cloud.githubusercontent.com/assets/2726409/16594482/81bc35ca-42e2-11e6-86e0-972ff3e0a70e.png)
- **Main Queue Context** hangs from a Private Context, so when save operations are made it doesn't freeze main thread when persisting data into the database. Saves from this context come from direct user interaction.
- **Private Queue Context** hangs from the same Private Context, and it is used to process batch updates into the database, from updates models that come from network requests. It is a sibling to _Main Queue Context_ and it is listening to his update notifications to merge changes.
- In my UIViewController I am using a `NSFetchedResultsController` that is fetching objects from the same entities than the ones used by the batch update operation happening in the background. It is using the _Main Queue Context_.

Under this scenario I get random deadlocks when a `performFetch:` from my `NSFetchedResultsController` happens at the same time the _Private Queue Context_ is reading/writing from the same entities.

I have also tried to follow recommendations from [Core Data Performance Optimization and Debugging](https://developer.apple.com/videos/play/wwdc2013/211/) video from WWDC 2013 and make my _Private Queue Context_ and _Main Queue Context_ use their own _Persistence Store Coordinators_, but when doing that I constantly get this error from save operations `Error Domain=NSSQLiteErrorDomain Code=5 "(null)" UserInfo={EncryptedStoreErrorMessage=database is locked}`.

When using a default store (non encrypted) there are no deadlocks and everything works fine.

I have added some unit tests that demonstrate the 3 different behaviors for each Core Data Stack. Different Core Data Stacks are running exactly the same tests and the results are:
#### Tests for the default SQLite Store
- `SingleDefaultStoreManager` defines the Core Data Stack described above by the image, and it uses a Store of type `NSSQLiteStoreType` with journal mode disabled, trying to simulate as much as possible the way EncryptedStore works.
- `testConcurrentInsertOperationsOnDefaultStore` and `testConcurrentUpdateOperationsOnDefaultStore` are passing consistently
#### Tests for the Encrypted Store
- `SingleEncryptedStoreManager` defines the Core Data Stack described above by the image, and it uses an Encrypted Store.
- `testConcurrentInsertOperationsOnEncryptedStore` fails most of the times (~80%) with error 
  `waitForExpectationsWithTimeout: timed out but was unable to run the timeout handler because the main thread was unresponsive (0.5 seconds is allowed after the wait times out). Conditions that may cause this include processing blocking IO on the main thread, calls to sleep(), deadlocks, and synchronous IPC. Xcode will attempt to relaunch the process and continue with the next test...`
- `testConcurrentUpdateOperationsOnEncryptedStore` fails all the times with the same error
#### Tests for the Double Encrypted Store
- `DoubleEncryptedStoreManager` defines the Core Data Stack, where _Main Queue Context_ and _Private Queue Context_ use different _Encrypted Stores_ that point to the same encrypted database.
- `testConcurrentInsertOperationsOnDoubleEncryptedStore` and `testConcurrentUpdateOperationsOnDoubleEncryptedStore` are failing consistently, because of error `Error Domain=NSSQLiteErrorDomain Code=5 "(null)" UserInfo={EncryptedStoreErrorMessage=database is locked}`
