### PR TITLE
Fixing (null) column name in relationship table

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -1680,7 +1680,7 @@ static void dbsqliteStripCaseDiacritics(sqlite3_context *context, int argc, cons
         *firstIDColumn = [NSString stringWithFormat:format, [rootSourceEntity.name stringByAppendingString:@"_1"]];
         *secondIDColumn = [NSString stringWithFormat:format, [rootDestinationEntity.name stringByAppendingString:@"_2"]];
         *firstOrderColumn = [NSString stringWithFormat:orderFormat, [rootSourceEntity.name stringByAppendingString:@"_1"]];
-        *firstOrderColumn = [NSString stringWithFormat:orderFormat, [rootDestinationEntity.name stringByAppendingString:@"_2"]];
+        *secondOrderColumn = [NSString stringWithFormat:orderFormat, [rootDestinationEntity.name stringByAppendingString:@"_2"]];
         
         return YES;
     }


### PR DESCRIPTION
A value should be assigned to firstOrderColumn and secondOrderColumn. It's assigned twice to firstOrderColumn instead. Produces columns with name (null).

CREATE TABLE ecd_friends_friends ('User_1__objectid' INTEGER NOT NULL, 'User_2__objectid' INTEGER NOT NULL, 'User_2_order' INTEGER DEFAULT 0, '(null)' INTEGER DEFAULT 0, PRIMARY KEY('User_1__objectid', 'User_2__objectid'))