### PR TITLE
Configure pragmas option

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -1272,8 +1272,6 @@ static const NSInteger kTableCheckVersion = 1;
                 // TO-DO: handle error with statement
                 NSLog(@"Error: statement is NULL or could not be finalized");
                 return NO;
-            } else {
-                return YES;
             }
         }
     }


### PR DESCRIPTION
Handle passing [SQLite PRAGMA statements](https://www.sqlite.org/pragma.html) in the store options with the [`NSSQLitePragmasOption` key](https://developer.apple.com/documentation/coredata/nssqlitepragmasoption). This can be used to specify the journal mode (e.g. `["journal_mode" : "WAL"]`) or busy timeout (e.g. `["busy_timeout" : "60000"]`), as well as [other functions](https://www.sqlite.org/pragma.html).