### PR TITLE
Use keys in dictionary if value for IN operator

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -4112,6 +4112,14 @@ static void dbsqliteStripCaseDiacritics(sqlite3_context *context, int argc, cons
                         [operator objectForKey:@"format"],
                         [parameters componentsJoinedByString:@", "]];
         }
+        else if ([value isKindOfClass:[NSDictionary class]]) {
+            NSUInteger count = [value count];
+            NSArray *parameters = [NSArray cmdArrayWithObject:@"?" times:count];
+            *bindings = [value allKeys];
+            *operand = [NSString stringWithFormat:
+                        [operator objectForKey:@"format"],
+                        [parameters componentsJoinedByString:@", "]];
+        }
         else if ([value isKindOfClass:[NSDate class]]) {
             *bindings = value;
             *operand = @"?";


### PR DESCRIPTION
This is the way the default `NSSQLiteStoreType` behaves. Iterating over an `NSDictionary` iterates over its keys as well.

Currently, if a dictionary is used as the value for `IN` in a predicate, it creates SQL: `SELECT ... FROM ... WHERE (... IN ?);` and produces the error `could not prepare statement: near "?": syntax error`.

With these changes, the SQL is: `SELECT ... FROM ... WHERE (... IN (?, ?, ...));`, where the bindings for `?, ?, ...` are the dictionary's keys.