### PR TITLE
#313 Migration fails due to Many to Many relation ship tables. Table …

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -2086,7 +2086,7 @@ static void dbsqliteStripCaseDiacritics(sqlite3_context *context, int argc, cons
 - (NSString *)tableNameForPreviousRelationship:(NSRelationshipDescription *)relationship
 {
     NSRelationshipDescription *inverse = [relationship inverseRelationship];
-    NSArray *names = [@[([relationship renamingIdentifier] ? [relationship renamingIdentifier] : [relationship name]), ([inverse renamingIdentifier] ? [inverse renamingIdentifier] : [inverse name])] sortedArrayUsingComparator:[self fixedLocaleCaseInsensitiveComparator]];
+    NSArray *names = @[([relationship renamingIdentifier] ? [relationship renamingIdentifier] : [relationship name]), ([inverse renamingIdentifier] ? [inverse renamingIdentifier] : [inverse name])];
     return [NSString stringWithFormat:@"ecd_%@",[names componentsJoinedByString:@"_"]];
 }
 /// Create columns for both object IDs. @returns YES  if the relationship.entity was first


### PR DESCRIPTION
As described the issue before, the lightweight migration fails due to Many to Many relation tables. 

While migration, Source and Destination table names are different. It might be happening because of `sorting` the table names array in the `tableNameForPreviousRelationship()`

Else we have interchange the `inverse` and `relationship` names at the `tableNameForRelationship()`

Both options are resolving the migration crash. I decided to remove the `sorting` option instead of interchange the `inverse` and `relationship` table names. 

Thanks