### PR TITLE
EncryptedStore: Fixed not throwing error in Swift

### DIFF
--- a/Incremental Store/EncryptedStore.m
+++ b/Incremental Store/EncryptedStore.m
@@ -282,10 +282,9 @@ static const NSInteger kTableCheckVersion = 1;
 
     persistentCoordinator = [self coordinator:persistentCoordinator byAddingStoreAtURL:databaseURL configuration:nil options:options error:error];
     
-    if (*error)
-    {
-        NSLog(@"Unable to add persistent store.");
-        NSLog(@"Error: %@\n%@\n%@", *error, [*error userInfo], [*error localizedDescription]);
+    if (*error) {
+        // Returning nil will cause the error object to be thrown as intended if this method is called in Swift
+        return nil;
     }
     
     return persistentCoordinator;
@@ -297,7 +296,12 @@ static const NSInteger kTableCheckVersion = 1;
     }
     
     [coordinator addPersistentStoreWithType:EncryptedStoreType configuration:configuration URL:url options:options error:error];
-    
+
+    if (*error) {
+        // Returning nil will cause the error object to be thrown as intended if this method is called in Swift
+        return nil;
+    }
+
     return coordinator;
 }
 
@@ -305,6 +309,12 @@ static const NSInteger kTableCheckVersion = 1;
     NSPersistentStoreDescription *description = [NSPersistentStoreDescription new];
     EncryptedStoreFileManager *fileManager = [options objectForKey:self.class.optionFileManager] ?: [EncryptedStoreFileManager defaultManager];
     [fileManager setupDatabaseWithOptions:options error:error];
+
+    if (*error) {
+        // Returning nil will cause the error object to be thrown as intended if this method is called in Swift
+        return nil;
+    }
+
     description.type = self.optionType;
     description.URL = fileManager.databaseURL;
     description.configuration = configuration;


### PR DESCRIPTION
• When an Objective-C method ends with a parameter that is a pointer to an error, it is imported to Swift as a method that throws. However, the error will only be thrown if the return value is either nil or false. All the public methods ending with an error pointer parameter were checked for this flaw. Only these three needed correction:
+ (NSPersistentStoreCoordinator *)coordinator:byAddingStoreAtURL:configuration:options:error:
+ (NSPersistentStoreCoordinator *)makeStoreWithOptions:managedObjectModel:error:
+ (NSPersistentStoreDescription *)makeDescriptionWithOptions:configuration:error: