### PR TITLE
Update podspec branch tag from 3.1 to 3.2

### DIFF
--- a/EncryptedCoreData.podspec
+++ b/EncryptedCoreData.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name          = 'EncryptedCoreData'
-    s.version       = '3.1'
+    s.version       = '3.2'
     s.license       = 'Apache-2.0'
   
     s.summary       = 'iOS Core Data encrypted SQLite store using SQLCipher'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
         'MITRE' => 'imas-proj-list@lists.mitre.org'
     }
   
-    s.source        = { :git => 'https://github.com/project-imas/encrypted-core-data.git', :tag => '3.1' }
+    s.source        = { :git => 'https://github.com/project-imas/encrypted-core-data.git', :tag => '3.2' }
   
     s.frameworks    = ['CoreData', 'Security']
     s.requires_arc  = true


### PR DESCRIPTION
I am trying to fix `error: implicit declaration of function 'sqlite3_key' is invalid in C99` in an underlying podspec.
With some hope, upgrading version will do the fix :) Any idea welcome.